### PR TITLE
reflect recent changes of MassiveThreads

### DIFF
--- a/Makefile.am.include
+++ b/Makefile.am.include
@@ -59,7 +59,7 @@ if EXAFMM_WITH_CILK
 LIBS += -lcilkrts
 endif
 if EXAFMM_WITH_MTHREAD
-LIBS += -lmyth-native
+LIBS += -lmyth
 endif
 
 ### Floating point precision

--- a/include/thread.h
+++ b/include/thread.h
@@ -26,7 +26,8 @@ using namespace tbb;
 
 #elif EXAFMM_WITH_MTHREAD
 /* MassiveThreads (TBB-like interface on top of MassiveThreads)  */
-#define num_threads(E)		      myth_init_ex(E, 1 << 16)
+//#define num_threads(E)		      myth_init_ex(E, 1 << 16)
+#define num_threads(E)		      do { myth_globalattr_set_stacksize(0, 1 << 16); myth_globalattr_set_n_workers(0, E); myth_init(); } while (0)
 #define TO_MTHREAD_NATIVE 1
 #include <tpswitch/tpswitch.h>
 


### PR DESCRIPTION
This patch reflects a few API changes in MassiveThreads.

(1) the native library name changes from libmyth-native to libmyth ( https://github.com/massivethreads/massivethreads/blob/master/README.md )
(2) initialization API slightly changed to accommodate more parameters.
( http://www.eidos.ic.i.u-tokyo.ac.jp/massivethreads/massivethreads/docs/reference/files/myth-h.html )
